### PR TITLE
EVEREST-726 remove build by tag

### DIFF
--- a/.github/workflows/percona-build-push.yml
+++ b/.github/workflows/percona-build-push.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - v*
 
 jobs:
 
@@ -21,12 +19,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            percona/everest-catalog,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, 'rc') }}
             perconalab/everest-catalog
           tags: |
-            type=match,pattern=v(.*),group=1
-            type=match,pattern=v(\d.\d),group=1
-            type=raw,value=latest,enable=true
+            type=raw,value=0.0.0,enable=${{ contains(github.ref_name, 'main') }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2


### PR DESCRIPTION
**RC/Release pipelines**
---
**Problem:**
EVEREST-726

The builds other than dev are moved to the [everest](https://github.com/percona/everest) repo. They get triggered by the release.yaml pipeline.

**Cause:**
Catalog needs the operator image to be present when the catalog gets regenerated, so we need to build images sequentially, we can't just build the image somewhere in parallel triggered by a new tag. 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
