### PR TITLE
EVEREST-950 remove dev image from stable channel

### DIFF
--- a/catalog/everest-operator/catalog.yaml
+++ b/catalog/everest-operator/catalog.yaml
@@ -16,7 +16,10 @@ package: everest-operator
 schema: olm.channel
 ---
 entries:
-- name: everest-operator.v0.0.0
+- name: everest-operator.v0.9.0
+- name: everest-operator.v0.9.1
+  skips:
+  - everest-operator.v0.9.0
 name: stable-v0
 package: everest-operator
 schema: olm.channel

--- a/catalog/everest-operator/veneer.yaml
+++ b/catalog/everest-operator/veneer.yaml
@@ -3,9 +3,10 @@ GenerateMajorChannels: true
 GenerateMinorChannels: false
 Fast:
   Bundles:
-  - Image: docker.io/perconalab/everest-operator-bundle:0.0.0
-  - Image: docker.io/perconalab/everest-operator-bundle:0.9.0
-  - Image: docker.io/perconalab/everest-operator-bundle:0.9.1
+    - Image: docker.io/perconalab/everest-operator-bundle:0.0.0
+    - Image: docker.io/perconalab/everest-operator-bundle:0.9.0
+    - Image: docker.io/perconalab/everest-operator-bundle:0.9.1
 Stable:
   Bundles:
-  - Image: docker.io/perconalab/everest-operator-bundle:0.0.0
+    - Image: docker.io/perconalab/everest-operator-bundle:0.9.0
+    - Image: docker.io/perconalab/everest-operator-bundle:0.9.1


### PR DESCRIPTION
EVEREST-950 

No need to keep operator 0.0.0 in the stable channel anymore even for the main branch. To build the latest main version of everest run `make build-cli`. The Everest pipelines are updated to use `make bulid-cli` instead of `go run` 

How to keep the operator images list consistent between the releases:
After the release merge the `everest-catalog` release branch to main (only for `everest-catalog`, other repos release branches shouldn't be merged)

Related PRs:
- https://github.com/percona/everest/pull/191