### PR TITLE
EVEREST-107 Remove the currentVersion parameter

### DIFF
--- a/tools/everest_basic_template.go
+++ b/tools/everest_basic_template.go
@@ -7,6 +7,7 @@ import (
 	"github.com/operator-framework/operator-registry/alpha/template/basic"
 	"gopkg.in/yaml.v3"
 	"os"
+	"strings"
 )
 
 const versionPrefix = "everest-operator.v"
@@ -66,6 +67,20 @@ func (t *EverestBasicTemplate) update(release release, channel string) error {
 	}
 	t.Entries = append(t.Entries, bundle)
 	return nil
+}
+
+func (t *EverestBasicTemplate) currentVersion(channel string) string {
+	for _, meta := range t.Entries {
+		if meta.Schema == declcfg.SchemaChannel && meta.Name == channel {
+			var ch declcfg.Channel
+			err := json.Unmarshal(meta.Blob, &ch)
+			if err != nil {
+				return ""
+			}
+			return strings.TrimPrefix(ch.Entries[len(ch.Entries)-1].Name, versionPrefix)
+		}
+	}
+	return ""
 }
 
 func updateBlob(channelBlob json.RawMessage, release release, channel string) ([]byte, error) {

--- a/tools/veneer-update.go
+++ b/tools/veneer-update.go
@@ -7,10 +7,9 @@ import (
 
 func main() {
 	var (
-		newVersion     string
-		currentVersion string
-		channel        string
-		veneerFile     string
+		newVersion string
+		channel    string
+		veneerFile string
 	)
 
 	rootCmd := &cobra.Command{
@@ -22,7 +21,7 @@ func main() {
 				err error
 			)
 
-			b, err = updateVeneer(veneerFile, channel, currentVersion, newVersion)
+			b, err = updateVeneer(veneerFile, channel, newVersion)
 			if err != nil {
 				panic(err)
 			}
@@ -32,7 +31,6 @@ func main() {
 	}
 
 	rootCmd.Flags().StringVar(&newVersion, "new-version", "", "New version (e.g. 0.10.0)")
-	rootCmd.Flags().StringVar(&currentVersion, "current-version", "", "Current version (e.g. 0.9.5)")
 	rootCmd.Flags().StringVar(&channel, "channel", "", "Channel to update (e.g. stable-v0)")
 	rootCmd.Flags().StringVar(&veneerFile, "veneer-file", "", "Path to veneer file")
 
@@ -41,17 +39,17 @@ func main() {
 	}
 }
 
-func updateVeneer(veneerFile, channel, currentVersionStr, newVersionStr string) ([]byte, error) {
-	var r release
-	err := r.create(currentVersionStr, newVersionStr)
-	if err != nil {
-		return nil, fmt.Errorf("%s: invalid version format: %w", newVersionStr, err)
-	}
-
+func updateVeneer(veneerFile, channel, newVersionStr string) ([]byte, error) {
 	var t EverestBasicTemplate
-	err = t.readFromFile(veneerFile)
+	err := t.readFromFile(veneerFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read template: %w", err)
+	}
+
+	var r release
+	err = r.create(t.currentVersion(channel), newVersionStr)
+	if err != nil {
+		return nil, fmt.Errorf("%s: invalid version format: %w", newVersionStr, err)
 	}
 
 	err = t.update(r, channel)

--- a/tools/veneer-update_test.go
+++ b/tools/veneer-update_test.go
@@ -12,49 +12,42 @@ func TestPatch(t *testing.T) {
 	testcases := []struct {
 		name           string
 		channel        string
-		currentVersion string
 		newVersion     string
 		expectedOutput string
 	}{
 		{
 			name:           "Non-rc patch release",
 			channel:        "fast-v0",
-			currentVersion: "0.9.1",
 			newVersion:     "0.9.2",
 			expectedOutput: nonRCPatchExpected,
 		},
 		{
 			name:           "RC patch release over non-rc release",
 			channel:        "fast-v0",
-			currentVersion: "0.9.1",
 			newVersion:     "0.9.2-rc1",
 			expectedOutput: rcPatchOverNonRCExpected,
 		},
 		{
 			name:           "RC patch version over RC",
 			channel:        "fast-v1",
-			currentVersion: "0.9.1-rc1",
 			newVersion:     "0.9.1-rc2",
 			expectedOutput: rcOverRcPatchExpected,
 		},
 		{
 			name:           "Non-RC minor release",
 			channel:        "fast-v0",
-			currentVersion: "0.9.1",
 			newVersion:     "0.10.0",
 			expectedOutput: nonRCMinorExpected,
 		},
 		{
 			name:           "Minor release's first RC",
 			channel:        "fast-v0",
-			currentVersion: "0.9.1",
 			newVersion:     "0.10.0-rc1",
 			expectedOutput: minorReleasesFirstRCExpected,
 		},
 		{
 			name:           "Minor release stable channel",
 			channel:        "stable-v0",
-			currentVersion: "0.9.1",
 			newVersion:     "0.10.0",
 			expectedOutput: minorReleaseStableChannelExpected,
 		},
@@ -64,7 +57,7 @@ func TestPatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			b, err := updateVeneer("./everest-operator_test.yaml", tt.channel, tt.currentVersion, tt.newVersion)
+			b, err := updateVeneer("./everest-operator_test.yaml", tt.channel, tt.newVersion)
 			require.NoError(t, err)
 			actual := string(b)
 			require.Equal(t, tt.expectedOutput, actual)


### PR DESCRIPTION
the `currentVersion` for a channel can be figured out, there's no need to ask for it