### PR TITLE
EVEREST-107 Remove trivy

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,13 +39,6 @@ jobs:
           tags: "perconalab/everest-catalog:0.0.0"
           file: everest-catalog.Dockerfile
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.12.0
-        with:
-          image-ref: "perconalab/everest-catalog:0.0.0"
-          format: 'table'
-          severity: 'CRITICAL,HIGH'
-
       - name: Run debug commands on failure
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/percona-build-push.yml
+++ b/.github/workflows/percona-build-push.yml
@@ -39,10 +39,3 @@ jobs:
           file: everest-catalog.Dockerfile
 
 
-#      - name: Run Trivy vulnerability scanner
-#        uses: aquasecurity/trivy-action@0.12.0
-#        with:
-#          image-ref: "perconalab/everest-catalog:0.0.0"
-#          format: 'table'
-#          exit-code: '1'
-#          severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
EVEREST-107

At some point trivy started to fail the pipelines from time to time bc of the `TOOMANYREQUESTS` error. There are several workarounds but none of them 100% guarantee. 
Since we have Snyk which also scans for vulnerabilities, I don't think it's worth to go through all the "try and fail" path with workarounds, let's solve it ultimately - remove trivy scans from the Everest pipelines. 