### PR TITLE
EVEREST-107 fix tests

### DIFF
--- a/tools/veneer-update.go
+++ b/tools/veneer-update.go
@@ -34,27 +34,36 @@ func main() {
 }
 
 func updateVeneer(veneerFile, channel, newVersionStr string) error {
+	b, err := updateVeneerImpl(veneerFile, channel, newVersionStr)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(veneerFile, b, 0644)
+}
+
+func updateVeneerImpl(veneerFile, channel, newVersionStr string) ([]byte, error) {
 	var t EverestBasicTemplate
 	err := t.readFromFile(veneerFile)
 	if err != nil {
-		return fmt.Errorf("failed to read template: %w", err)
+		return nil, fmt.Errorf("failed to read template: %w", err)
 	}
 
 	var r release
 	err = r.create(t.currentVersion(channel), newVersionStr)
 	if err != nil {
-		return fmt.Errorf("%s: invalid version format: %w", newVersionStr, err)
+		return nil, fmt.Errorf("%s: invalid version format: %w", newVersionStr, err)
 	}
 
 	err = t.update(r, channel)
 	if err != nil {
-		return fmt.Errorf("failed to update template: %w", err)
+		return nil, fmt.Errorf("failed to update template: %w", err)
 	}
 
 	b, err := t.toByteArray()
 	if err != nil {
-		return fmt.Errorf("failed to convert data: %w", err)
+		return nil, fmt.Errorf("failed to convert data: %w", err)
 	}
 
-	return os.WriteFile(veneerFile, b, 0644)
+	return b, nil
 }

--- a/tools/veneer-update_test.go
+++ b/tools/veneer-update_test.go
@@ -57,7 +57,7 @@ func TestPatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			b, err := updateVeneer("./everest-operator_test.yaml", tt.channel, tt.newVersion)
+			b, err := updateVeneerImpl("./everest-operator_test.yaml", tt.channel, tt.newVersion)
 			require.NoError(t, err)
 			actual := string(b)
 			require.Equal(t, tt.expectedOutput, actual)


### PR DESCRIPTION
In https://github.com/percona/everest-catalog/pull/33 the tool that updates catalog started to write the release-related changes directly to the file instead of returning a string, however the tests were not updated accordingly. This PR fixes it. 