### PR TITLE
ci: declare explicit token permissions for build-and-push workflow

### DIFF
--- a/.github/workflows/percona-build-push.yml
+++ b/.github/workflows/percona-build-push.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
 


### PR DESCRIPTION
## Problem

The org-level default for `GITHUB_TOKEN` was changed to **read repository contents**. This workflow has no `permissions:` block, so it was relying on the previous read/write default.

It logs into `ghcr.io` using `secrets.GITHUB_TOKEN` and runs `push: true`:

```yaml
- name: Login to GitHub Container Registry
  uses: docker/login-action@v3
  with:
    registry: ${{ env.REGISTRY }}
    username: ${{ github.actor }}
    password: ${{ secrets.GITHUB_TOKEN }}
```

Pushing a package with `GITHUB_TOKEN` requires `packages: write`, so without this change the next push to `main` fails at the registry step.

## Change

Adds a top-level block declaring the minimum the job actually uses:

```yaml
permissions:
  contents: read
  packages: write
```

`contents: read` for `actions/checkout`, `packages: write` for the ghcr push. Nothing else in the workflow uses the token.

This restores exactly the access the job was implicitly getting before, without the rest of the write scopes it never needed.

## Notes

- The workflow only triggers on `push` to `main`, so release branches are unaffected.
- Actions in this file are pinned to mutable tags (`actions/checkout@v4`, `docker/login-action@v3`, `docker/build-push-action@v6`). Worth pinning to SHAs, but that's a separate change and deliberately not bundled here.
