### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/build-verify-on-PR.yml
+++ b/.github/workflows/build-verify-on-PR.yml
@@ -11,9 +11,9 @@ jobs:
     
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
   
       - name: Validate Contribution
-        uses: joelanford/opm-validate@main
+        uses: joelanford/opm-validate@1cc529703fd0d46b2eb2b23ea9b561a040f4ca5c # v0.1.0
         with:
           catalog: catalog

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Check default main state - generated files for postgresql-operator
         run: |
@@ -34,7 +34,7 @@ jobs:
           git diff --exit-code
 
       - name: Build image to check it for vulnerabilities
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: false

--- a/.github/workflows/percona-build-push.yml
+++ b/.github/workflows/percona-build-push.yml
@@ -20,11 +20,11 @@ jobs:
       EVEREST_CATALOG_DEV_IMAGE_NAME: 'openeverest-catalog-dev'
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: |
             ${{ env.IMAGE_PREFIX }}/${{ env.EVEREST_CATALOG_DEV_IMAGE_NAME }}
@@ -33,14 +33,14 @@ jobs:
             type=raw,value=latest,enable=${{ contains(github.ref_name, 'main') }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: true


### PR DESCRIPTION
## Why

Actions must now be pinned to full-length commit SHAs at the org level. A mutable tag means the action's owner — or anyone who compromises them — can change what executes in our pipelines retroactively, and unpinned workflows no longer run.

## What

Every `uses:` tag reference is replaced with the commit SHA that tag points at today, keeping the human-readable version in a trailing comment:

```diff
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
```

- **Behaviour-preserving** — same code runs, it just can't change underneath us.
- Annotated tags were dereferenced to the underlying commit.
- Comments use the most specific release tag pointing at that commit (`v4.4.0` rather than `v4`), matching the convention already used in `openeverest/main`.
- Line-for-line; no reordering or reformatting.

Generated mechanically and YAML-validated. Part of an org-wide sweep across all repositories.
