### PR TITLE
ci: declare explicit token permissions for workflows

### DIFF
--- a/.github/workflows/build-verify-on-PR.yml
+++ b/.github/workflows/build-verify-on-PR.yml
@@ -5,6 +5,9 @@ on:
     branches: 
     - '**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - main
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Checks


### PR DESCRIPTION
## Why

Neither workflow declares a `permissions:` block, so both inherit the org-level default for `GITHUB_TOKEN`. That default was recently changed to **read repository contents**, so nothing is broken today — but a workflow that doesn't state its needs silently tracks whatever the org setting happens to be, with no review signal when it changes.

## Changes

Both get `contents: read` — they check out and run validation only, with no token writes:

- `build-verify-on-PR.yml`
- `checks.yml`

The repo's third workflow, `percona-build-push.yml`, already declares `contents: read` + `packages: write` (#87).
